### PR TITLE
fix: nvim_echo not allowed in loop callback

### DIFF
--- a/lua/md-pdf/utils.lua
+++ b/lua/md-pdf/utils.lua
@@ -14,14 +14,14 @@ function M.log_error(str)
     if type(str) ~= "string" then
         str = tostring(str)
     end
-    vim.notify("md-pdf: " .. str, vim.log.levels.ERROR)
+    pcall(vim.notify,"md-pdf: " .. str, vim.log.levels.ERROR)
 end
 
 function M.log_info(str)
     if type(str) ~= "string" then
         str = tostring(str)
     end
-    vim.notify("md-pdf: " .. str)
+    pcall(vim.notify,"md-pdf: " .. str)
 end
 
 return M


### PR DESCRIPTION
closes #8
Simple `pcall` wrappers around loggers to suppress errors from nvim. There are no functional restrictions.