### PR TITLE
feat: Add title page option and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ require('md-pdf').setup({
     highlight = "tango",
     -- Generate a table of contents, on by default
     toc = true,
+    -- Render a dedicated title page (and keep ToC on a separate page)
+    title_page = false,
     -- Define a custom preview command, enabling hooks and other custom logic
     preview_cmd = function() return 'firefox' end,
     -- if true, then the markdown file is continuously converted on each write, even if the

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ vim.keymap.set("n", "<Space>,", function()
 end)
 ```
 
+### Title page metadata
+
+When `title_page = true`, add a standard Pandoc/YAML front matter block to your markdown file. Fields like `title`, `author`, `date`, and an optional `logo` (relative to the markdown file, e.g. `assets/logo.png`) are picked up automatically and rendered on the dedicated title page.
+
 ## Requirements
 
 > [!WARNING]

--- a/lua/md-pdf/config.lua
+++ b/lua/md-pdf/config.lua
@@ -23,6 +23,8 @@ local defaults = {
     highlight = "tango",
     ---@type boolean Generate a table of contents, on by default
     toc = true,
+    ---@type boolean Render a separate title page (followed by an optional TOC page)
+    title_page = false,
     ---@type function The command to open the pdf with
     preview_cmd = M.default_preview_cmd,
     ---@type boolean if true, then the markdown file is continuously converted on each write,

--- a/lua/md-pdf/init.lua
+++ b/lua/md-pdf/init.lua
@@ -175,6 +175,7 @@ function M.convert_md_to_pdf()
 
     local pandoc_args = {
         "pandoc",
+        "--standalone",
         "-V",
         "geometry:margin=" .. config.options.margins,
         fullname,


### PR DESCRIPTION
## Summary
- add bool `title_page`  dedicated to render a title sheet followed by an isolated table of contents
- to design the title page supply a YAML block for example:

```yaml
---
title: The Test Of All 
author: marc 
date: November 2025 
logo: assets/logo.png
---
```